### PR TITLE
Remove hardcoding guild id

### DIFF
--- a/src/main/java/dev/cortex/cortexbot/services/DiscordBot.java
+++ b/src/main/java/dev/cortex/cortexbot/services/DiscordBot.java
@@ -133,7 +133,7 @@ public class DiscordBot {
     }
 
     public static Guild getGuild() {
-        return getApi().getGuildById("503656531665879063");
+        return getApi().getGuildById(discordConfiguration.getGuildId());
     }
 
     public void addRoleToMember(net.dv8tion.jda.api.entities.Member member, long roleId) {


### PR DESCRIPTION
Use the guild id from the properties file instead of hardcoding. This fixes #17 